### PR TITLE
Add vitest dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.76.1",
     "axios": "^1.12.2",
+    "node": "^25.2.0",
     "prop-types": "^15.8.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
@@ -46,6 +47,7 @@
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "jsdom": "^27.1.0",
-    "vite": "^7.1.7"
+    "vite": "^7.1.7",
+    "vitest": "^4.0.9"
   }
 }


### PR DESCRIPTION
getting some errors when running the frontend. apparently the vite config file was trying to import vitest but vitest was not in package.json, so it was resulting in an error. this fixes it