### PR TITLE
Password too short popup

### DIFF
--- a/src/components/LoginSignup/LoginSignup.jsx
+++ b/src/components/LoginSignup/LoginSignup.jsx
@@ -22,7 +22,6 @@ function LoginSignup() {
 
     try {
       if (action === 'Sign Up') {
-        if (action === 'Sign Up') {
         // alert user if the password they tried is too short
         if (!password || password.length < MIN_PASSWORD_LENGTH) {
           alert(`Password must be at least ${MIN_PASSWORD_LENGTH} characters long.`);


### PR DESCRIPTION
fix for issue 57 here: https://github.com/CrossWars-Project/FrontEnd/issues/57
right now min password length is 6 per supabase auth table settings
<img width="562" height="797" alt="Screenshot 2025-11-24 at 12 44 03 PM" src="https://github.com/user-attachments/assets/d5761a2b-da73-48cf-a24f-f22a94a3c44f" />
