### PR TITLE
there is now a back button in stats

### DIFF
--- a/src/components/Stats/Stats.jsx
+++ b/src/components/Stats/Stats.jsx
@@ -3,10 +3,14 @@ import './Stats.css';
 import PropTypes from 'prop-types';
 import { UserAuth } from '../../context/AuthContext';
 import { getUserStats } from '../../api';
-import logo from '../assets/logo.png'; //import logo image so correct path is used
+import { useNavigate } from 'react-router-dom';
+import {
+  FaCog, FaSignOutAlt, FaUserFriends, FaUser, FaHashtag,
+} from 'react-icons/fa';
 
 export default function Stats({ userStats }) {
   const { user } = UserAuth();
+  const navigate = useNavigate();
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -58,7 +62,16 @@ export default function Stats({ userStats }) {
   return (
     <div className="stats-container">
       <div className="logo-container">
-        <img src={logo} alt="Cross Wars Logo" className="logo" />
+        <img src="src/components/assets/logo.png" alt="Cross Wars Logo" className="logo" />
+      </div>
+      <div className="top-buttons">
+        <button
+          type="button"
+          className="top-button gray"
+          onClick={() => navigate('/dashboard')}
+        >
+          <FaSignOutAlt /> Back
+        </button>
       </div>
 
       <h2 className="stats-title">


### PR DESCRIPTION
<img width="1382" height="732" alt="Screenshot 2025-12-02 at 3 09 19 PM" src="https://github.com/user-attachments/assets/11b7faa5-e6fe-4ae5-b880-e59bd87eb6b9" />
button ^

can change it to say 'exit' to be consistent with the button in dashboard, although that is a logout button so exit makes more sense there. In gameplay the button says "quit", but again that is cuz you are quitting the game. So I think back makes most sense because when you leave stats it routes back to dashboard. But i am down to change it if people have strong feelings.